### PR TITLE
Return the empty json instead of empty string.

### DIFF
--- a/DSSV1/operations/Server.ts
+++ b/DSSV1/operations/Server.ts
@@ -98,8 +98,8 @@ export class Server {
     */
     private async getResponseContent(response: httpClient.HttpClientResponse): Promise<string> {
         if (!this.isSuccessStatusCode(response.message.statusCode)) {
-            console.log(`server.getResponseContent: failed code ${response.message.statusCode}`);
-            return "";
+            console.log(`server.getResponseContent: failed code ${response.message.statusCode} and response body ${await response.readBody()}`);
+            return "{}";
         }
 
         let body: string = await response.readBody();


### PR DESCRIPTION
Print the response object to display the proper error message and code.